### PR TITLE
Implemented the select to speak functionality.

### DIFF
--- a/Morphic.Client/DefaultPreferences.json
+++ b/Morphic.Client/DefaultPreferences.json
@@ -23,10 +23,6 @@
       {
         "type": "control",
         "feature": "contrast"
-      },
-      {
-        "type": "control",
-        "feature": "speech"
       }
     ]
   }

--- a/Morphic.Client/DefaultPreferences.json
+++ b/Morphic.Client/DefaultPreferences.json
@@ -23,6 +23,10 @@
       {
         "type": "control",
         "feature": "contrast"
+      },
+      {
+        "type": "control",
+        "feature": "speech"
       }
     ]
   }

--- a/Morphic.Client/QuickStrip/QuickStripSegmentedButtonControl.xaml.cs
+++ b/Morphic.Client/QuickStrip/QuickStripSegmentedButtonControl.xaml.cs
@@ -68,6 +68,12 @@ namespace Morphic.Client
             style.Setters.Add(new Setter { Property = ActionButton.FontFamilyProperty, Value = SystemFonts.MessageFontFamily });
             style.Setters.Add(new Setter { Property = ActionButton.FontSizeProperty, Value = 14.0 });
             style.Setters.Add(new Setter { Property = ActionButton.FontWeightProperty, Value = FontWeight.FromOpenTypeWeight(700) });
+            
+            // Fade the button if it's disabled.
+            var trigger = new Trigger { Property = ActionButton.IsEnabledProperty, Value = false };
+            trigger.Setters.Add(new Setter{ Property =  ActionButton.OpacityProperty, Value = 0.5});
+            style.Triggers.Add(trigger);
+
             return style;
         }
 
@@ -113,6 +119,16 @@ namespace Morphic.Client
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Toggles the enabled state of a button.
+        /// </summary>
+        /// <param name="index">The button index.</param>
+        /// <param name="enabled">The enabled state.</param>
+        public void EnableButton(int index, bool enabled)
+        {
+            this.ActionStack.Children[index].IsEnabled = enabled;
         }
 
         /// <summary>

--- a/Morphic.Client/QuickStrip/QuickStripWindow.xaml.cs
+++ b/Morphic.Client/QuickStrip/QuickStripWindow.xaml.cs
@@ -31,12 +31,19 @@ using Morphic.Settings;
 using System.Windows.Media.Animation;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Interop;
 using System.Windows.Media.Imaging;
 using Microsoft.Win32;
 using CountlySDK;
+using Morphic.Windows.Native;
+using Display = Morphic.Settings.Display;
 
 namespace Morphic.Client.QuickStrip
 {
+    using System.Windows.Forms;
+    using Clipboard = System.Windows.Clipboard;
+    using IDataObject = System.Windows.IDataObject;
+
     /// <summary>
     /// Interaction logic for QuickStripWindow.xaml
     /// </summary>
@@ -73,6 +80,12 @@ namespace Morphic.Client.QuickStrip
         private void OnLoaded(object? sender, RoutedEventArgs e)
         {
             Reposition(animated: false);
+
+            // Start monitoring the active window.
+            WindowInteropHelper nativeWindow = new WindowInteropHelper(this);
+            HwndSource hwndSource = HwndSource.FromHwnd(nativeWindow.Handle);
+            SelectionReader.Default.Initialise(nativeWindow.Handle);
+            hwndSource?.AddHook(SelectionReader.Default.WindowProc);
         }
 
         private readonly Session session;
@@ -327,6 +340,16 @@ namespace Morphic.Client.QuickStrip
                             control.Action += quickStrip.OnCursorColor;
                             return control;
                         }
+                    case "speech":
+                        {
+                            var control = new QuickStripSegmentedButtonControl();
+                            control.TitleLabel.Content = "Read text";
+                            control.AddButton("\u25b6", "Speak the selected text", "Select some text, and click the button to read it aloud.", isPrimary: true);
+                            control.AddButton("\u25a0", "Stop speech", "Stop the current speech.", isPrimary: false);
+                            control.EnableButton(1, false);
+                            control.Action += quickStrip.OnSpeakSelection;
+                            return control;
+                        }
                     default:
                         return null;
                 }
@@ -455,6 +478,56 @@ namespace Morphic.Client.QuickStrip
                     { SettingsManager.Keys.WindowsCursorArrow, "%SystemRoot%\\cursors\\arrow_r.cur" },
                     { SettingsManager.Keys.WindowsCursorWait, "%SystemRoot%\\cursors\\busy_r.cur" },
                 });
+            }
+        }
+
+        private async void OnSpeakSelection(object sender, QuickStripSegmentedButtonControl.ActionEventArgs e)
+        {
+            SelectionReader reader = SelectionReader.Default;
+            Speech speech = Speech.Default;
+            
+            // Play/Pause
+            if (e.SelectedIndex == 0)
+            {
+
+                if (speech.Active)
+                {
+                    // Pause or resume it
+                    speech.TogglePause();
+                }
+                else
+                {
+                    QuickStripSegmentedButtonControl itemControl = (QuickStripSegmentedButtonControl)sender;
+                    itemControl.EnableButton(1, true);
+                    
+                    // Store the clipboard
+                    IDataObject clipboadData = Clipboard.GetDataObject();
+                    Dictionary<string, object> dataStored = clipboadData.GetFormats()
+                        .ToDictionary(format => format, format => clipboadData.GetData(format, false));
+                    Clipboard.Clear();
+
+                    // Get the selection
+                    await reader.GetSelectedText(SendKeys.SendWait);
+                    string text = Clipboard.GetText();
+
+                        // Restore the clipboard
+                        Clipboard.Clear();
+                        dataStored.Where(kv => kv.Value != null).ToList()
+                            .ForEach(kv => Clipboard.SetData(kv.Key, kv.Value));
+                        Clipboard.Flush();
+
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        await speech.SpeakText(text);
+                    }
+
+                    itemControl.EnableButton(1, false);
+                }
+            }
+            else
+            {
+                // Stop
+                speech.StopSpeaking();
             }
         }
 

--- a/Morphic.Windows.Native/Speech/SelectionReader.cs
+++ b/Morphic.Windows.Native/Speech/SelectionReader.cs
@@ -1,0 +1,155 @@
+﻿// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under 
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and 
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants 
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant 
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+namespace Morphic.Windows.Native
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Reads the selected text from most windows.
+    /// </summary>
+    public class SelectionReader
+    {
+        public static readonly SelectionReader Default = new SelectionReader();
+
+        private int shellMessage;
+
+        private IntPtr activeWindow;
+        private IntPtr lastWindow;
+        private readonly uint processId;
+        
+
+        /// <summary>Set when the active window has changed.</summary>
+        private readonly AutoResetEvent gotActiveWindow = new AutoResetEvent(false);
+
+        /// <summary>Set when the clipboard has been updated.</summary>
+        private readonly AutoResetEvent gotClipboard = new AutoResetEvent(false);
+
+        private SelectionReader()
+        {
+            using Process process = Process.GetCurrentProcess();
+            this.processId = (uint) process.Id;
+        }
+
+        public void Initialise(IntPtr hwnd)
+        {
+            if (this.shellMessage == 0)
+            {
+                this.shellMessage = WindowsApi.RegisterWindowMessage("SHELLHOOK");
+                WindowsApi.RegisterShellHookWindow(hwnd);
+                WindowsApi.AddClipboardFormatListener(hwnd);
+            }
+        }
+
+        /// <summary>
+        /// Gets the selected text of the given window, or the last activate window.
+        /// </summary>
+        /// <param name="sendKeys">The <c>SendKeys.SendWait</c> method.</param>
+        /// <param name="windowHandle">The window.</param>
+        /// <returns>The selected text.</returns>
+        public async Task GetSelectedText(Action<string> sendKeys, IntPtr? windowHandle = null)
+        {
+            IntPtr hwnd = windowHandle ?? this.lastWindow;
+            await Task.Run(() =>
+            {
+                if (hwnd != IntPtr.Zero)
+                {
+                    // Activate the window, if it's not already.
+                    IntPtr active = WindowsApi.GetForegroundWindow();
+                    if (active != hwnd)
+                    {
+                        this.gotActiveWindow.Reset();
+                        WindowsApi.SetForegroundWindow(hwnd);
+
+                        // Wait for it to be activated.
+                        this.gotActiveWindow.WaitOne(3000);
+                    }
+                }
+
+                // Copy the selected text to clipboard
+                this.gotClipboard.Reset();
+                sendKeys("^c");
+
+                // Wait for the clipboard update.
+                this.gotClipboard.WaitOne(3000);
+            });
+
+            return;
+        }
+
+        /// <summary>
+        /// A Window procedure - handles window messages for a window.
+        /// Pass this method to HwndSource.AddHook().
+        /// </summary>
+        /// <param name="hwnd">The window handle.</param>
+        /// <param name="msg">The message.</param>
+        /// <param name="wParam">Message data.</param>
+        /// <param name="lParam">Message data.</param>
+        /// <param name="handled">Set to true if the message has been handled</param>
+        /// <returns>The message result.</returns>
+        public IntPtr WindowProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            switch ((WindowsApi.WindowMessages) msg)
+            {
+                case WindowsApi.WindowMessages.WM_CLIPBOARDUPDATE:
+                    // The clipboard has been updated.
+                    this.gotClipboard.Set();
+                    handled = true;
+                    break;
+
+                default:
+                    if (msg == this.shellMessage)
+                    {
+                        // A window has been activated.
+                        if (wParam.ToInt32() == WindowsApi.HSHELL_WINDOWACTIVATED
+                            || wParam.ToInt32() == WindowsApi.HSHELL_RUDEAPPACTIVATED)
+                        {
+                            // The activated window is passed via lParam, but this wasn't accurate
+                            // for Modern UI apps.
+                            IntPtr window = WindowsApi.GetForegroundWindow();
+                            if (this.activeWindow != window)
+                            {
+                                this.activeWindow = window;
+
+                                // Ignore the application's window
+                                WindowsApi.GetWindowThreadProcessId(window, out uint pid);
+                                if (pid != this.processId)
+                                {
+                                    this.lastWindow = window;
+                                }
+
+                                this.gotActiveWindow.Set();
+                            }
+                        }
+                    }
+
+                    break;
+            }
+
+            return IntPtr.Zero;
+        }
+    }
+}

--- a/Morphic.Windows.Native/Speech/Speech.cs
+++ b/Morphic.Windows.Native/Speech/Speech.cs
@@ -65,7 +65,7 @@ namespace Morphic.Windows.Native
                 "Add-Type -AssemblyName System.speech;"
                 + "$speech = New-Object System.Speech.Synthesis.SpeechSynthesizer;"
                 + "$semaphor = [System.Threading.EventWaitHandle]::OpenExisting(\"morphic-speech\");"
-                + $"$speech.SpeakAsync(\"{text}\");"
+                + "$speech.SpeakAsync($Env:MORPHIC_SPEECH);"
                 + "while($speech.State -ne [System.Speech.Synthesis.SynthesizerState]::Ready)"
                 + "{"
                 + "    if ($semaphor.WaitOne(200)) {"
@@ -84,6 +84,7 @@ namespace Morphic.Windows.Native
                     "-ExecutionPolicy", "bypass",
                     "-NoProfile", "-NonInteractive", "-Command", script
                 },
+                Environment = { {"MORPHIC_SPEECH", text} },
                 CreateNoWindow = true,
             });
             

--- a/Morphic.Windows.Native/Speech/Speech.cs
+++ b/Morphic.Windows.Native/Speech/Speech.cs
@@ -1,0 +1,131 @@
+﻿// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under 
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and 
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants 
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant 
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+namespace Morphic.Windows.Native
+{
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Performs text to speech. 
+    /// </summary>
+    public class Speech
+    {
+        public static readonly Speech Default = new Speech();
+        
+        /// <summary>Used to tell the speech process to pause/resume.</summary>
+        private EventWaitHandle toggleSpeech = new EventWaitHandle(false, EventResetMode.AutoReset, "morphic-speech");
+        /// <summary>Cancellation for the speech process.</summary>
+        private CancellationTokenSource? cancellation;
+
+        /// <summary>true if currently speaking.</summary>
+        public bool Active => this.cancellation != null;
+
+        private Speech()
+        {
+        }
+
+        /// <summary>
+        /// Says the given text.
+        /// </summary>
+        /// <param name="text">The text to say.</param>
+        /// <returns>Task, completing when the speech is done.</returns>
+        public Task<bool> SpeakText(string text)
+        {
+            if (this.cancellation != null)
+            {
+                this.StopSpeaking();
+            }
+            
+            // The speech API is only available for .NET framework, so access it via powershell.
+            // This script invokes the speech synthesizer, waiting for a signal from this process to pause/resume
+            // the speech.
+            string script =             
+                "Add-Type -AssemblyName System.speech;"
+                + "$speech = New-Object System.Speech.Synthesis.SpeechSynthesizer;"
+                + "$semaphor = [System.Threading.EventWaitHandle]::OpenExisting(\"morphic-speech\");"
+                + $"$speech.SpeakAsync(\"{text}\");"
+                + "while($speech.State -ne [System.Speech.Synthesis.SynthesizerState]::Ready)"
+                + "{"
+                + "    if ($semaphor.WaitOne(200)) {"
+                + "        if ($speech.State -eq [System.Speech.Synthesis.SynthesizerState]::Paused) {"
+                + "            $speech.Resume();"
+                + "        } else {"
+                + "            $speech.Pause();"
+                + "        }"
+                + "    }"
+                + "};";
+            
+            Process process = Process.Start(new ProcessStartInfo()
+            {
+                FileName = "powershell.exe",
+                ArgumentList = {
+                    "-ExecutionPolicy", "bypass",
+                    "-NoProfile", "-NonInteractive", "-Command", script
+                },
+                CreateNoWindow = true,
+            });
+            
+            this.cancellation = new CancellationTokenSource();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            if (process == null)
+            {
+                task.SetCanceled();
+            }
+            else
+            {
+                // Kill the process when the task is cancelled.
+                this.cancellation.Token.Register(process.Kill);
+                
+                // Complete the task when the process ends.
+                process.EnableRaisingEvents = true;
+                process.Exited += (sender, args) =>
+                {
+                    task.SetResult(process.ExitCode == 0);
+                    this.cancellation = null;
+                    process.Dispose();
+                };
+            }
+
+            return task.Task;
+        }
+
+        /// <summary>Stop talking.</summary>
+        public void StopSpeaking()
+        {
+            if (this.cancellation != null)
+            {
+                this.cancellation.Cancel();
+                this.cancellation.Dispose();
+                this.cancellation = null;
+            }
+        }
+
+        /// <summary>Pause or resume the speech.</summary>
+        public void TogglePause()
+        {
+            this.toggleSpeech.Set();
+        }
+    }
+}

--- a/Morphic.Windows.Native/WindowsApi.cs
+++ b/Morphic.Windows.Native/WindowsApi.cs
@@ -469,6 +469,36 @@ namespace Morphic.Windows.Native
         internal const Int32 E_OUTOFMEMORY = unchecked((Int32)0x8007000E);
         internal const Int32 E_POINTER = unchecked((Int32)0x80004003);
 
+        // Shell hook messages.
+        // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registershellhookwindow
+        internal const int HSHELL_WINDOWACTIVATED = 4;
+        internal const int HSHELL_RUDEAPPACTIVATED = 0x8004;
+
+        internal enum WindowMessages : int
+        {
+            WM_CLIPBOARDUPDATE = 0x031D
+        }
+
+        /// <summary>
+        /// The HIWORD macro.
+        /// </summary>
+        /// <param name="dwValue">The value to be converted.</param>
+        /// <returns>The high-order word of the specified value.</returns>
+        internal static short HighWord(this int dwValue)
+        {
+            return ((short)(dwValue >> 16));
+        }
+
+        /// <summary>
+        /// The LOWORD macro.
+        /// </summary>
+        /// <param name="dwValue">The value to be converted.</param>
+        /// <returns>The low-order word of the specified value.</returns>
+        internal static short LowWord(this int n)
+        {
+            return ((short)(n & 0xffff));
+        }
+
         /* user32 */
         //
         // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-changedisplaysettingsexw
@@ -506,6 +536,34 @@ namespace Morphic.Windows.Native
         // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getsystemmetricsfordpi
         [DllImport("user32.dll")]
         internal static extern Int32 GetSystemMetricsForDpi(SystemMetricIndex nIndex, UInt32 dpi);
+        //
+        // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setforegroundwindow
+        [DllImport("user32.dll")]
+        internal static extern bool SetForegroundWindow(IntPtr hWnd);
+        //
+        // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getforegroundwindow
+        [DllImport("user32.dll")]
+        internal static extern IntPtr GetForegroundWindow();
+        //
+        // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registershellhookwindow
+        [DllImport("user32.dll")]
+        internal static extern bool RegisterShellHookWindow(IntPtr hWnd);
+        //
+        // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerwindowmessagea
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        internal static extern int RegisterWindowMessage(string lpString);
+        //
+        // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-addclipboardformatlistener
+        [DllImport("user32.dll")]
+        internal static extern bool AddClipboardFormatListener(IntPtr hwnd);
+        //
+        // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-removeclipboardformatlistener
+        [DllImport("user32.dll")]
+        internal static extern bool RemoveClipboardFormatListener(IntPtr hwnd);
+        //
+        // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowthreadprocessid
+        [DllImport("user32.dll", SetLastError=true)]
+        internal static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
     }
 }


### PR DESCRIPTION
Closes #62 

![image](https://user-images.githubusercontent.com/1867587/83870843-d9a0a080-a726-11ea-8d68-975a14195821.png)

Select text, then click the button to read it.

This uses the clipboard to read the selection. While effort is made to restore the user's clipboard, there may be data loss for complex clipboard content (the clipboard can contain objects).

The speech API [System.Speech.Synthesis](https://docs.microsoft.com/en-us/dotnet/api/system.speech.synthesis.speechsynthesizer?view=netframework-4.8) is only available for .NET Framework (not core). This is invoked by spawning a powershell process - I think anything beyond simple start/stop of speech would require a better approach.