### PR TITLE
attempt to make hide magnifier work reliably

### DIFF
--- a/Morphic.Client/QuickStrip/QuickStripWindow.xaml.cs
+++ b/Morphic.Client/QuickStrip/QuickStripWindow.xaml.cs
@@ -386,7 +386,7 @@ namespace Morphic.Client.QuickStrip
         }
 
         /// <summary>Original magnifier settings.</summary>
-        private Dictionary<Preferences.Key, object?> magnifyCapture;
+        private Dictionary<Preferences.Key, object?>? magnifyCapture;
         
         private async void OnMagnify(object sender, QuickStripSegmentedButtonControl.ActionEventArgs e)
         {
@@ -401,10 +401,11 @@ namespace Morphic.Client.QuickStrip
                     {SettingsManager.Keys.WindowsMagnifierEnabled, true},
                 };
 
-                if (this.magnifyCapture == null)
+                if (magnifyCapture == null)
                 {
                     // capture the current settings
-                    this.magnifyCapture = await this.session.SettingsManager.Capture(settings.Keys);
+                    magnifyCapture = await session.SettingsManager.Capture(settings.Keys);
+                    magnifyCapture[SettingsManager.Keys.WindowsMagnifierEnabled] = false;
                 }
 
                 await session.Apply(settings);
@@ -413,11 +414,14 @@ namespace Morphic.Client.QuickStrip
             {
                 _ = Countly.RecordEvent("Hide Magnifier");
                 // restore settings
-                await session.Apply(SettingsManager.Keys.WindowsMagnifierEnabled, false);
-                if (this.magnifyCapture != null)
+                if (magnifyCapture != null)
                 {
-                    await this.session.Apply(this.magnifyCapture);
-                    this.magnifyCapture = null;
+                    await session.Apply(magnifyCapture);
+                    magnifyCapture = null;
+                }
+                else
+                {
+                    await session.Apply(SettingsManager.Keys.WindowsMagnifierEnabled, false);
                 }
             }
         }

--- a/Morphic.Client/Solutions/windows.solutions.json
+++ b/Morphic.Client/Solutions/windows.solutions.json
@@ -72,10 +72,15 @@
         "type": "integer",
         "default": 2,
         "handler": {
-          "type": "com.microsoft.windows.registry",
-          "key_name": "HKEY_CURRENT_USER\\Software\\Microsoft\\ScreenMagnifier",
-          "value_name": "MagnificationMode",
-          "value_type": "dword"
+          "type": "com.microsoft.windows.system",
+          "setting_id": "SystemSettings_Accessibility_Magnifier_Mode",
+          "value_type": "string",
+          "integer_map": [
+            "",
+            "SystemSettings_Accessibility_Magnifier_ModeDocked",
+            "SystemSettings_Accessibility_Magnifier_ModeFullScreen",
+            "SystemSettings_Accessibility_Magnifier_ModeLens"
+          ]
         }
       },
       {
@@ -83,10 +88,9 @@
         "type": "integer",
         "default": 200,
         "handler": {
-          "type": "com.microsoft.windows.registry",
-          "key_name": "HKEY_CURRENT_USER\\Software\\Microsoft\\ScreenMagnifier",
-          "value_name": "Magnification",
-          "value_type": "dword"
+          "type": "com.microsoft.windows.system",
+          "setting_id": "SystemSettings_Accessibility_Magnifier_Magnification",
+          "value_type": "integer"
         }
       },
       {


### PR DESCRIPTION
Hide magnifier sometimes results with magnifier ending up in Full Screen mode.

I tried a couple changes, but still the same result:

- Use system instead of registry setting handlers
- Ensure the captured value for enabled is false, don't double-set enabled

@stegru Any ideas?  Seems like a timing thing with windows.