### PR TITLE
MOR-44: Renamed "Text Size" to "Screen Zoom"

### DIFF
--- a/Morphic.Client/Properties/Resources.Designer.cs
+++ b/Morphic.Client/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Morphic.Client.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -278,7 +278,7 @@ namespace Morphic.Client.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Increase Text Size.
+        ///   Looks up a localized string similar to Increase Screen Zoom.
         /// </summary>
         internal static string QuickStrip_Resolution_Bigger_HelpTitle {
             get {
@@ -296,7 +296,7 @@ namespace Morphic.Client.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot Increase Text Size.
+        ///   Looks up a localized string similar to Cannot Increase Screen Zoom.
         /// </summary>
         internal static string QuickStrip_Resolution_Bigger_LimitTitle {
             get {
@@ -314,7 +314,7 @@ namespace Morphic.Client.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Decrease Text Size.
+        ///   Looks up a localized string similar to Decrease Screen Zoom.
         /// </summary>
         internal static string QuickStrip_Resolution_Smaller_HelpTitle {
             get {
@@ -332,7 +332,7 @@ namespace Morphic.Client.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot Decrease Text Size.
+        ///   Looks up a localized string similar to Cannot Decrease Screen Zoom.
         /// </summary>
         internal static string QuickStrip_Resolution_Smaller_LimitTitle {
             get {
@@ -341,7 +341,7 @@ namespace Morphic.Client.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Text Size.
+        ///   Looks up a localized string similar to Screen Zoom.
         /// </summary>
         internal static string QuickStrip_Resolution_Title {
             get {

--- a/Morphic.Client/Properties/Resources.resx
+++ b/Morphic.Client/Properties/Resources.resx
@@ -191,28 +191,28 @@
     <value>Make all the text and icons bigger</value>
   </data>
   <data name="QuickStrip_Resolution_Bigger_HelpTitle" xml:space="preserve">
-    <value>Increase Text Size</value>
+    <value>Increase Screen Zoom</value>
   </data>
   <data name="QuickStrip_Resolution_Bigger_LimitMessage" xml:space="preserve">
     <value>The text and icons are as large as they can be</value>
   </data>
   <data name="QuickStrip_Resolution_Bigger_LimitTitle" xml:space="preserve">
-    <value>Cannot Increase Text Size</value>
+    <value>Cannot Increase Screen Zoom</value>
   </data>
   <data name="QuickStrip_Resolution_Smaller_HelpMessage" xml:space="preserve">
     <value>Make all the text and icons smaller</value>
   </data>
   <data name="QuickStrip_Resolution_Smaller_HelpTitle" xml:space="preserve">
-    <value>Decrease Text Size</value>
+    <value>Decrease Screen Zoom</value>
   </data>
   <data name="QuickStrip_Resolution_Smaller_LimitMessage" xml:space="preserve">
     <value>The text and icons are as small as they can be</value>
   </data>
   <data name="QuickStrip_Resolution_Smaller_LimitTitle" xml:space="preserve">
-    <value>Cannot Decrease Text Size</value>
+    <value>Cannot Decrease Screen Zoom</value>
   </data>
   <data name="QuickStrip_Resolution_Title" xml:space="preserve">
-    <value>Text Size</value>
+    <value>Screen Zoom</value>
   </data>
   <data name="QuickStrip_Volume_Down_HelpMessage" xml:space="preserve">
     <value>Make all the sounds quieter</value>


### PR DESCRIPTION
Like the title says, renamed the "Text Size" text to "Screen Zoom".
